### PR TITLE
Change partial HTTP request interface

### DIFF
--- a/lib/range-request-factory.ts
+++ b/lib/range-request-factory.ts
@@ -26,6 +26,9 @@ export class RangeRequestFactory {
       this.config = {...this.config, ...config};
     }
     const headRequestInfo = await this.getHeadRequestInfo();
+    if (!headRequestInfo.acceptPartialRequests) {
+      throw new Error('Server does not accept partial requests');
+    }
     return new RangeRequestTokenizer(this.rangeRequestClient, headRequestInfo, this.config.minimumChunkSize);
   }
 
@@ -45,7 +48,7 @@ export class RangeRequestFactory {
     if (this.rangeRequestClient.getHeadInfo) {
       const info = await this.rangeRequestClient.getHeadInfo();
       if (info.size) {
-        debug(`MIME-type=${info.mimeType}, content-length=${info.size}`);
+        debug(`MIME-type=${info.mimeType}, content-length=${info.size}, accept-partial-requests=${info.acceptPartialRequests}`);
         return info;
       }
     }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -27,12 +27,15 @@ export interface IContentRangeType {
  */
 export interface IHeadRequestInfo extends IFileInfo {
   /**
-   * Range and file size specification
+   * Accept partial requests
    */
-  contentRange?: IContentRangeType;
+  acceptPartialRequests: boolean;
 }
 
 export interface IRangeRequestResponse extends IHeadRequestInfo {
+
+  contentRange?: IContentRangeType;
+
   arrayBuffer: () => Promise<Uint8Array>;
 }
 

--- a/test/FsRangeRequestClient.ts
+++ b/test/FsRangeRequestClient.ts
@@ -16,6 +16,7 @@ export class FsRangeRequestClient implements IRangeRequestClient {
     return {
       size: stat.size,
       mimeType: this.getContentType() ?? undefined,
+      acceptPartialRequests: true,
       path: this.fixturePath
     };
   }
@@ -27,6 +28,7 @@ export class FsRangeRequestClient implements IRangeRequestClient {
       size: stat.size,
       mimeType: this.getContentType() ?? undefined,
       arrayBuffer: () => this.getData(range),
+      acceptPartialRequests: true,
       path: this.fixturePath
     };
   }


### PR DESCRIPTION
Update interface to allow the implementing HTTP client to check the [HTTP `Accept-Ranges` headers](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept-Ranges), for partial HTTP request support.